### PR TITLE
Use available arguments to override defaults

### DIFF
--- a/importer/make_KMB_info.py
+++ b/importer/make_KMB_info.py
@@ -30,7 +30,9 @@ class KMBInfo(MakeBaseInfo):
 
     def __init__(self, **options):
         """Initialise a make_info object."""
-        super(KMBInfo, self).__init__(BATCH_CAT, BATCH_DATE, **options)
+        batch_date = options.get('batch_label') or BATCH_DATE
+        batch_cat = options.get('base_meta_cat') or BATCH_CAT
+        super(KMBInfo, self).__init__(batch_cat, batch_date, **options)
         self.commons = pywikibot.Site('commons', 'commons')
         self.wikidata = pywikibot.Site('wikidata', 'wikidata')
         self.category_cache = {}  # cache for category_exists()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/wikimedia/pywikibot-core.git
-git+https://github.com/lokal-profil/BatchUploadTools.git@0.1.6
+git+https://github.com/lokal-profil/BatchUploadTools.git@0.1.7


### PR DESCRIPTION
The default values are hard coded, by allowing them as command
line args we open up for reusing the code for later batches or
(for log files) to distinguish test runs.

Task: [T170529](https://phabricator.wikimedia.org/T170529)