### PR TITLE
Match Sweden church categories

### DIFF
--- a/importer/make_KMB_info.py
+++ b/importer/make_KMB_info.py
@@ -590,19 +590,28 @@ class KMBItem(object):
         if at least one of the parents of the exact
         category is in the item's categories. The parent
         categories are then removed.
+
+        Simplified handling if item is a church.
         """
         exact_match = False
         exact_category_from_name = self.kmb_info.category_exists(self.namn, cache)
         if exact_category_from_name:
             exact_category_from_name = pywikibot.Page(self.commons, self.namn)
-            parent_cats = exact_category_from_name.categories()
-            for cat in parent_cats:
-                cat_name = cat.title(withNamespace=False)
-                if cat_name in self.content_cats:
+            if "kyrka" in self.namn.lower():
+                # church - don't check parent cats.
+                # only check if disambig (e.g. Category:Ljungby kyrka)
+                if not exact_category_from_name.isDisambig():
                     exact_match = True
-                    # if its parent(s) is in this item's cat,
-                    # we can assume it's correct
-                    self.content_cats.discard(cat_name)
+            else:
+                # not a church - check parent cats
+                parent_cats = exact_category_from_name.categories()
+                for cat in parent_cats:
+                    cat_name = cat.title(withNamespace=False)
+                    if cat_name in self.content_cats:
+                        exact_match = True
+                        # if its parent(s) is in this item's cat,
+                        # we can assume it's correct
+                        self.content_cats.discard(cat_name)
 
         if exact_match is True:
             exact_category_title = exact_category_from_name.title(withNamespace=False)


### PR DESCRIPTION
Right now, trying to identify exact categories via the short name doesn't work for churches in Sweden, as it relies on immediate parent categories (church cats are rarely directly inside Category:$place Municipality.

Try to find a solution to identify exact categories for churches.

Task: https://phabricator.wikimedia.org/T176879